### PR TITLE
changed: replace deprecated paginate in hugo

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -16,7 +16,6 @@ defaultContentLanguage: en
 # This will make .Summary and .WordCount behave correctly for CJK languages.
 hasCJKLanguage: false
 
-# Update pagination setting
 pagination:
   pagerSize: 9
 

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -2,7 +2,6 @@
 baseurl: https://awesome-arabic-speakers.dev/
 languageCode: en-us
 relativeURLs: true
-paginate: 9
 title: Awesome Arabic Speakers
 
 services:
@@ -16,6 +15,10 @@ defaultContentLanguage: en
 # Set hasCJKLanguage to true if DefaultContentLanguage is in [zh-cn ja ko]
 # This will make .Summary and .WordCount behave correctly for CJK languages.
 hasCJKLanguage: false
+
+# Update pagination setting
+pagination:
+  pagerSize: 9
 
 taxonomies:
   category: categories


### PR DESCRIPTION
### What is your contribution type?


- [x] Web site maintenance.


### What's in this PR?

- Replacing ```paginate``` with ```pagination.pagerSize``` since it has been deprecated #32 

### Checklist

- [x] Ensure to check our [Contribution Criteria](../blob/main/CONTRIBUTING.md#criteria).
- [x] The contribution doesn't already exist (you can use [search functionality](https://awesome-arabic-speakers.dev/search/)).